### PR TITLE
Delete result for not cought exception

### DIFF
--- a/docs/ch10-01-exceptions.md
+++ b/docs/ch10-01-exceptions.md
@@ -230,15 +230,6 @@ int main() {
 }
 ```
 
-実行結果は次のようになります。
-
-```txt
-$ ./a.out
-terminate called after throwing an instance of 'std::runtime_error'
-  what():  数値ではない文字が入っています
-Aborted (core dumped)
-```
-
 ## noexcept
 
 関数が例外を送出しないことを明示的に表すには `noexcept` をつけます。


### PR DESCRIPTION
例外のキャッチ漏れは `std::terminate()` を呼び出すのが言語仕様ですが、
Windows の MSYS2 環境 (MinGW?) での挙動はやや異なるようで、
ターミナル上では何も表示されませんでした。

```
$ ./a.exe

$ 
```

main 関数の return 直前にある
`std::cout << num << std::endl;`
という処理も実行されていないため main 関数を抜けるところまでは期待通りの動作になっており、
その後の動作が `std::terminate` とは異なる Windows 固有の異常終了処理などを行っている
のではないかと推測しています。

現在の実行結果は Linux におけるもので、
Windows での実行結果と異なる例を載せるのは誤解を招くおそれがあるため一旦削除します。