### PR TITLE
Delete example for std::runtime_error because std::locale not work in MinGW environment

### DIFF
--- a/docs/ch10-01-exceptions.md
+++ b/docs/ch10-01-exceptions.md
@@ -397,40 +397,7 @@ try {
 実行時に評価する値の不正や実行環境の問題など
 実行時エラーを表すためのクラスです。
 
-`std::locale` で実行環境にないロケールを指定した場合などに送出されます。
-
-```cpp
-#include <iostream>
-#include <locale>
-
-void ShowValidLocales(const std::string& locale_name) {
-    try {
-        std::locale locale(locale_name);
-        std::cout << locale.name() << std::endl;
-    } catch (std::runtime_error& e) {
-        // 無効な場合にはエラーメッセージを標準エラーに出力
-        std::cerr << e.what() << std::endl;
-    }
-}
-
-int main() {
-    ShowValidLocales("en_US.UTF-8");
-    ShowValidLocales("ja_JP.UTF-8");
-    ShowValidLocales("zh_CN.UTF-8");
-
-    return 0;
-}
-```
-
-英語(米国)と日本語(日本)はあるが、
-簡体字中国語(中国)がない環境で実行すると以下のようになります。
-
-```bash
-$ ./a.out
-en_US.UTF-8
-ja_JP.UTF-8
-locale::facet::_S_create_c_locale name not valid
-```
+<!-- TODO: std::locale 以外での例を追加する -->
 
 ### std::bad_cast
 


### PR DESCRIPTION
`std::locale` は MinGW 環境では `C` と `POSIX` 以外の文字列をサポートしておらず、
Windows 環境では `std::runtime_error` の説明で使用した動作にはなりませんでした。

そのため、一旦 `std::runtime_error` の具体例の説明を削除して TODO コメントを追加します。

参考:
https://stackoverflow.com/questions/4406895/what-stdlocale-names-are-available-on-common-windows-compilers